### PR TITLE
fix: drop Node.js v10 and v12 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [10, 16, 18]
+        node_version: [14, 18, 19]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node_version }}
       - name: install
         run: |
           npm install

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=10.10.0"
+    "node": ">=14.17.0"
   },
   "scripts": {
     "clean": "rimraf lib",


### PR DESCRIPTION
BREAKING CHANGE: Node.js version 14 or later is required